### PR TITLE
Support user defined base url for queries

### DIFF
--- a/cs/config.go
+++ b/cs/config.go
@@ -18,8 +18,6 @@ import (
 var defaultCfgFile = ".codesearch"
 var token string
 
-const defaultBaseURL string = "https://api.github.com/"
-
 func initConfig() {
 	if flags.cfgFile != "" {
 		viper.SetConfigFile(flags.cfgFile)
@@ -38,6 +36,7 @@ func initConfig() {
 		fatalf("couldn't determine your home directory: %v", err)
 	}
 	viper.SetDefault("token_file", filepath.Join(home, ".codesearch_token"))
+	viper.SetDefault("base_url", "https://api.github.com/")
 
 	if err := viper.ReadInConfig(); err != nil {
 		setupFlow()
@@ -193,19 +192,16 @@ across owners, you can unset it here.
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "set-base-url",
-		Short: "Set base url of the query endpoint",
-		Long: `
-If you are using Github Enterprise, the deafult github query endpoints wont work.
-		`,
+		Short: "Control which GitHub instance you talk to by setting the base URL (eg: GitHub Enterprise)",
 		Run: func(cmd *cobra.Command, args []string) {
 			var answer string
-			fmt.Print("What base-url name would you like to set?: ")
+			fmt.Print("What base_url name would you like to set?: ")
 			fmt.Scanln(&answer)
 			if !strings.HasSuffix(answer, "/") {
 				answer = answer + "/"
 			}
 
-			viper.Set("base-url", answer)
+			viper.Set("base_url", answer)
 			err := viper.WriteConfig()
 			if err != nil {
 				fatalf("couldn't save config: %v", err)
@@ -220,7 +216,7 @@ If you are using Github Enterprise, the deafult github query endpoints wont work
 Use the default github api endpoint.
 		`,
 		Run: func(cmd *cobra.Command, args []string) {
-			viper.Set("base-url", "")
+			viper.Set("base_url", "")
 			err := viper.WriteConfig()
 			if err != nil {
 				fatalf("couldn't save config: %v", err)
@@ -255,7 +251,7 @@ func setupFlow() {
 	}
 
 	baseURL := askForBaseURL()
-	viper.Set("base-url", baseURL)
+	viper.Set("base_url", baseURL)
 
 	err = viper.SafeWriteConfig()
 	if err != nil {
@@ -299,15 +295,14 @@ selected ones are supplementary.
 
 func askForBaseURL() string {
 	color.Blue(`
-Set your own BaseURL if you are using Github Enterpise. Otherwise leave blank.
-Default is set to %s
-	`, defaultBaseURL)
+Not using GitHub Enterprise? Just press enter!
+	`)
 
-	fmt.Print("BaseURL: ")
+	fmt.Print("Base URL [https://api.github.com/]: ")
 	var baseURL string
 	fmt.Scanln(&baseURL)
 	if len(baseURL) == 0 {
-		return defaultBaseURL
+		return "https://api.github.com/"
 	}
 	// the github client enforces a trailing slash for POST calls so lets just enforce here
 	if !strings.HasSuffix(baseURL, "/") {

--- a/cs/config.go
+++ b/cs/config.go
@@ -302,7 +302,7 @@ Not using GitHub Enterprise? Just press enter!
 	var baseURL string
 	fmt.Scanln(&baseURL)
 	if len(baseURL) == 0 {
-		return "https://api.github.com/"
+		return viper.GetString("base_url")
 	}
 	// the github client enforces a trailing slash for POST calls so lets just enforce here
 	if !strings.HasSuffix(baseURL, "/") {

--- a/cs/config.go
+++ b/cs/config.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
@@ -200,6 +201,9 @@ If you are using Github Enterprise, the deafult github query endpoints wont work
 			var answer string
 			fmt.Print("What base-url name would you like to set?: ")
 			fmt.Scanln(&answer)
+			if !strings.HasSuffix(answer, "/") {
+				answer = answer + "/"
+			}
 
 			viper.Set("base-url", answer)
 			err := viper.WriteConfig()
@@ -295,15 +299,19 @@ selected ones are supplementary.
 
 func askForBaseURL() string {
 	color.Blue(`
-	Set your own BaseURL if you are using Github Enterpise. Otherwise leave blank.
-	Default is set to "https://api.github.com/"
-	`)
+Set your own BaseURL if you are using Github Enterpise. Otherwise leave blank.
+Default is set to %s
+	`, defaultBaseURL)
 
 	fmt.Print("BaseURL: ")
 	var baseURL string
 	fmt.Scanln(&baseURL)
 	if len(baseURL) == 0 {
 		return defaultBaseURL
+	}
+	// the github client enforces a trailing slash for POST calls so lets just enforce here
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL = baseURL + "/"
 	}
 	return baseURL
 }

--- a/cs/gql.go
+++ b/cs/gql.go
@@ -15,13 +15,23 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"text/template"
 	"time"
 
 	"github.com/spf13/viper"
 )
 
-var gqlURL = "https://api.github.com/graphql"
+func gqlURL() string {
+	baseURL, ok := viper.Get("base-url").(string)
+	if !ok || len(baseURL) == 0 {
+		baseURL = defaultBaseURL
+	}
+	if strings.HasSuffix(baseURL, "/") {
+		return baseURL + "graphql"
+	}
+	return baseURL + "/graphql"
+}
 
 type gqlRequest struct {
 	Query     string `json:"query"`
@@ -97,7 +107,7 @@ func getDefaultBranches(client *http.Client, result SearchResult) map[string]str
 		fatalf("failed to create gql request as json: %v", err)
 	}
 
-	resp, err := client.Post(gqlURL, "application/json", bytes.NewReader(gql))
+	resp, err := client.Post(gqlURL(), "application/json", bytes.NewReader(gql))
 	if err != nil {
 		fatalf("gql request to fetch branches failed: %v", err)
 	}
@@ -240,7 +250,7 @@ func getFullText(client *http.Client, result SearchResult, defaultBranches map[s
 		fatalf("failed to create gql request as json: %v", err)
 	}
 
-	resp, err := client.Post(gqlURL, "application/json", bytes.NewReader(gql))
+	resp, err := client.Post(gqlURL(), "application/json", bytes.NewReader(gql))
 	if err != nil {
 		fatalf("gql request to fetch file contents failed: %v", err)
 	}

--- a/cs/gql.go
+++ b/cs/gql.go
@@ -23,10 +23,7 @@ import (
 )
 
 func gqlURL() string {
-	baseURL, ok := viper.Get("base-url").(string)
-	if !ok || len(baseURL) == 0 {
-		baseURL = defaultBaseURL
-	}
+	baseURL := viper.Get("base_url").(string)
 	if strings.HasSuffix(baseURL, "/") {
 		return baseURL + "graphql"
 	}

--- a/cs/main.go
+++ b/cs/main.go
@@ -106,7 +106,7 @@ func init() {
 
 	rootCmd.Flags().IntVar(&flags.tabWidth, "tabwidth", 2, "number of spaces to display tabs as")
 
-	rootCmd.Flags().StringVar(&flags.baseURL, "base-url", "https://api.github.com/", "base url for api endpoint")
+	rootCmd.Flags().StringVar(&flags.baseURL, "base_url", "https://api.github.com/", "base url for api endpoint")
 
 	// TODO: Unfortunately only cs.github.com has archive term support at the moment
 	// rootCmd.Flags().BoolVarP(&flags.includeArchived, "archived", "a", false, "include results from archived repositories")
@@ -115,7 +115,7 @@ func init() {
 	viper.BindPFlag("format", rootCmd.Flags().Lookup("format"))
 	viper.BindPFlag("tabwidth", rootCmd.Flags().Lookup("tabwidth"))
 	viper.BindPFlag("url", rootCmd.Flags().Lookup("url"))
-	viper.BindPFlag("base-url", rootCmd.Flags().Lookup("base-url"))
+	viper.BindPFlag("base_url", rootCmd.Flags().Lookup("base_url"))
 
 	// TODO: have an interactive option that's just a glorified `less` with the
 	// ability to toggle fully-qualified repo + path + whatever metadata without

--- a/cs/main.go
+++ b/cs/main.go
@@ -106,7 +106,7 @@ func init() {
 
 	rootCmd.Flags().IntVar(&flags.tabWidth, "tabwidth", 2, "number of spaces to display tabs as")
 
-	rootCmd.Flags().StringVar(&flags.baseURL, "base_url", "https://api.github.com/", "base url for api endpoint")
+	rootCmd.Flags().StringVar(&flags.baseURL, "base-url", "https://api.github.com/", "base url for api endpoint")
 
 	// TODO: Unfortunately only cs.github.com has archive term support at the moment
 	// rootCmd.Flags().BoolVarP(&flags.includeArchived, "archived", "a", false, "include results from archived repositories")
@@ -115,7 +115,7 @@ func init() {
 	viper.BindPFlag("format", rootCmd.Flags().Lookup("format"))
 	viper.BindPFlag("tabwidth", rootCmd.Flags().Lookup("tabwidth"))
 	viper.BindPFlag("url", rootCmd.Flags().Lookup("url"))
-	viper.BindPFlag("base_url", rootCmd.Flags().Lookup("base_url"))
+	viper.BindPFlag("base-url", rootCmd.Flags().Lookup("base_url"))
 
 	// TODO: have an interactive option that's just a glorified `less` with the
 	// ability to toggle fully-qualified repo + path + whatever metadata without

--- a/cs/main.go
+++ b/cs/main.go
@@ -68,6 +68,8 @@ var flags = struct {
 	dumpData  bool
 	tabWidth  int
 
+	baseURL string
+
 	// includeArchived bool
 }{}
 
@@ -104,6 +106,8 @@ func init() {
 
 	rootCmd.Flags().IntVar(&flags.tabWidth, "tabwidth", 2, "number of spaces to display tabs as")
 
+	rootCmd.Flags().StringVar(&flags.baseURL, "base-url", "https://api.github.com/", "base url for api endpoint")
+
 	// TODO: Unfortunately only cs.github.com has archive term support at the moment
 	// rootCmd.Flags().BoolVarP(&flags.includeArchived, "archived", "a", false, "include results from archived repositories")
 
@@ -111,6 +115,7 @@ func init() {
 	viper.BindPFlag("format", rootCmd.Flags().Lookup("format"))
 	viper.BindPFlag("tabwidth", rootCmd.Flags().Lookup("tabwidth"))
 	viper.BindPFlag("url", rootCmd.Flags().Lookup("url"))
+	viper.BindPFlag("base-url", rootCmd.Flags().Lookup("base-url"))
 
 	// TODO: have an interactive option that's just a glorified `less` with the
 	// ability to toggle fully-qualified repo + path + whatever metadata without
@@ -302,7 +307,10 @@ func performSearch(ctx context.Context, query string, limit int) ([]*github.Code
 		v("Performing search took %s", time.Since(start))
 	}()
 
-	client := github.NewClient(getAuthenticatedHTTP(ctx))
+	client, err := githubClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 	v("User-Agent: %s", client.UserAgent)
 
 	opts := &github.SearchOptions{TextMatch: true}

--- a/cs/utils.go
+++ b/cs/utils.go
@@ -43,9 +43,6 @@ func getAuthenticatedHTTP(ctx context.Context) *http.Client {
 }
 
 func githubClient(ctx context.Context) (*github.Client, error) {
-	baseURL, ok := viper.Get("base-url").(string)
-	if !ok || len(baseURL) == 0 {
-		return github.NewEnterpriseClient(defaultBaseURL, defaultBaseURL, getAuthenticatedHTTP(ctx))
-	}
+	baseURL := viper.Get("base_url").(string)
 	return github.NewEnterpriseClient(baseURL, baseURL, getAuthenticatedHTTP(ctx))
 }

--- a/cs/utils.go
+++ b/cs/utils.go
@@ -7,6 +7,8 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/google/go-github/v47/github"
+	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 
@@ -38,4 +40,12 @@ func getAuthenticatedHTTP(ctx context.Context) *http.Client {
 		&oauth2.Token{AccessToken: token},
 	)
 	return oauth2.NewClient(ctx, ts)
+}
+
+func githubClient(ctx context.Context) (*github.Client, error) {
+	baseURL, ok := viper.Get("base-url").(string)
+	if !ok || len(baseURL) == 0 {
+		return github.NewEnterpriseClient(defaultBaseURL, defaultBaseURL, getAuthenticatedHTTP(ctx))
+	}
+	return github.NewEnterpriseClient(baseURL, baseURL, getAuthenticatedHTTP(ctx))
 }


### PR DESCRIPTION
Problem:
This did not support Github Enterprise environments because a user could not define a base URL to be used for queries.

Changes:
A user can define a base URL or use the default public github api.

Testing:
I tested a single query against the public github api and a single query to a github enterprise instance.
I also set/unset the base-url value in the config ensuring the defaults work properly.